### PR TITLE
rz-cmn: add function to get board info from QSPI

### DIFF
--- a/plat/renesas/rz/common/bl31_plat_setup.c
+++ b/plat/renesas/rz/common/bl31_plat_setup.c
@@ -16,6 +16,8 @@
 #include <rz_private.h>
 #include <rzg2l_def.h>
 
+#include <board_info.h>
+
 static const mmap_region_t rzg2l_mmap[] = {
 	MAP_REGION_FLAT(RZG2L_SRAM_BASE, RZG2L_SRAM_SIZE,
 			MT_MEMORY | MT_RW | MT_SECURE),
@@ -23,11 +25,15 @@ static const mmap_region_t rzg2l_mmap[] = {
 			MT_DEVICE | MT_RW | MT_SECURE),
 	MAP_REGION_FLAT(RZG2L_DDR1_BASE, RZG2L_DDR1_SIZE,
 			MT_MEMORY | MT_RW | MT_SECURE),
+	MAP_REGION_FLAT(RZG2L_SPIROM_BASE, RZG2L_SPIROM_SIZE,
+			MT_MEMORY | MT_RW | MT_SECURE),
 	{0}
 };
 
 static console_t rzg2l_bl31_console;
 static bl2_to_bl31_params_mem_t from_bl2;
+
+entry_point_info_t *bl31_plat_get_next_image_ep_info(uint32_t type);
 
 void bl31_early_platform_setup2(u_register_t arg0,
 								u_register_t arg1,
@@ -78,6 +84,18 @@ void bl31_platform_setup(void)
 	plat_gic_driver_init();
 	plat_gic_init();
 #endif
+
+	/* Read model and revision id from QSPI */
+	uint32_t model = get_board_info_u32(RZG2L_SPIROM_BASE, BOARD_INFO_QSPI_OFFSET, OFFSET_MODEL_ID);
+	uint32_t revision = get_board_info_u32(RZG2L_SPIROM_BASE, BOARD_INFO_QSPI_OFFSET, OFFSET_REVISION);
+
+	/* Get entry point info for BL33 */
+	entry_point_info_t *bl33_ep_info = bl31_plat_get_next_image_ep_info(NON_SECURE);
+
+	if (bl33_ep_info != NULL) {
+		bl33_ep_info->args.arg2 = model;
+		bl33_ep_info->args.arg3 = revision;
+	}
 }
 
 entry_point_info_t *bl31_plat_get_next_image_ep_info(uint32_t type)

--- a/plat/renesas/rz/common/board_info.c
+++ b/plat/renesas/rz/common/board_info.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025, Renesas Electronics Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <platform_def.h>
+#include <lib/mmio.h>
+#include <assert.h>
+#include <board_info.h>
+
+/**
+ * get_board_info_field - Read a 32-bit field from the board info region
+ *
+ * @flash_base:           Base address of the memory-mapped QSPI flash.
+ * @board_info_offset:    Offset to the start of the board info structure.
+ * @field_offset:         Offset to a specific field within the structure.
+ *
+ * Returns the 32-bit value read from flash_base + board_info_offset + field_offset.
+ */
+uint32_t get_board_info_u32(uintptr_t flash_base, size_t board_info_offset, size_t field_offset)
+{
+	uintptr_t addr = flash_base + board_info_offset + field_offset;
+
+	/* Check invalid access to board info region */
+	if (addr < flash_base + BOARD_INFO_QSPI_OFFSET ||
+		addr + sizeof(uint32_t) - 1 > flash_base + BOARD_INFO_QSPI_END) {
+		ERROR("Board info offset out of bounds: addr=0x%lx (valid: 0x%lx - 0x%lx)\n",
+			addr,
+			flash_base + BOARD_INFO_QSPI_OFFSET,
+			flash_base + BOARD_INFO_QSPI_END);
+#if DEBUG
+		assert(0);
+#else
+		panic();
+#endif
+	}
+
+	return mmio_read_32(addr);
+}
+
+/**
+ * get_board_info_string - Read a string field from the board info region
+ *
+ * @flash_base:           Base address of the memory-mapped QSPI flash.
+ * @board_info_offset:    Offset to the start of the board info structure.
+ * @field_offset:         Offset to a specific field within the structure.
+ * @buf:                  Buffer to store the string.
+ * @len:                  Length of the buffer.
+ *
+ * Reads a string from flash_base + board_info_offset + field_offset into buf.
+ * Ensures the string is null-terminated.
+ *
+ */
+void get_board_info_string(uintptr_t flash_base, size_t board_info_offset, size_t field_offset, char *buf, size_t len)
+{
+
+	uintptr_t addr = flash_base + board_info_offset + field_offset;
+
+	/* Check invalid access to board info region */
+	if (addr < flash_base + BOARD_INFO_QSPI_OFFSET ||
+		addr + sizeof(uint32_t) - 1 > flash_base + BOARD_INFO_QSPI_END) {
+		ERROR("Board info offset out of bounds: addr=0x%lx (valid: 0x%lx - 0x%lx)\n",
+				addr,
+				flash_base + BOARD_INFO_QSPI_OFFSET,
+				flash_base + BOARD_INFO_QSPI_END);
+#if DEBUG
+		assert(0);
+#else
+		panic();
+#endif
+	}
+
+	if (!buf || len == 0)
+		return;
+
+	size_t bytes_read = 0;
+	size_t total_bytes = len - 1;
+
+	while (bytes_read < total_bytes) {
+		uint32_t val = mmio_read_32(addr + bytes_read);
+
+		/* Extract each byte from the 32-bit word in little-endian order and store in buffer */
+		buf[bytes_read++] = (val >> 0) & 0xFF;
+		if (bytes_read >= total_bytes) break;
+
+		buf[bytes_read++] = (val >> 8) & 0xFF;
+		if (bytes_read >= total_bytes) break;
+
+		buf[bytes_read++] = (val >> 16) & 0xFF;
+		if (bytes_read >= total_bytes) break;
+
+		buf[bytes_read++] = (val >> 24) & 0xFF;
+	}
+
+	buf[bytes_read] = '\0';
+}

--- a/plat/renesas/rz/common/include/board_info.h
+++ b/plat/renesas/rz/common/include/board_info.h
@@ -1,0 +1,49 @@
+#ifndef BOARD_INFO_H
+#define BOARD_INFO_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* Offset range of board information within the QSPI flash region */
+#define BOARD_INFO_QSPI_OFFSET U(0x1C700)
+#define BOARD_INFO_QSPI_END    U(0x1CF0F)
+
+#define MAX_STRING_LEN           256
+
+/* Offsets for various fields inside the board info region */
+#define OFFSET_MODEL_ID          0x00
+#define OFFSET_REVISION          0x04
+#define OFFSET_MODEL_STRING      0x08
+#define OFFSET_MFG_NAME          0x08 + MAX_STRING_LEN
+
+/**
+ * get_board_info_u32 - Read a 32-bit field from the board info region
+ *
+ * @flash_base:           Base address of the memory-mapped QSPI flash.
+ * @board_info_offset:    Offset to the start of the board info structure.
+ * @field_offset:         Offset to a specific field within the structure.
+ *
+ * Example:
+ *   uint32_t model_id = get_board_info_u32(RZG2L_SPIROM_BASE, BOARD_INFO_QSPI_OFFSET, OFFSET_MODEL_ID);
+ */
+uint32_t get_board_info_u32(uintptr_t flash_base, size_t board_info_offset, size_t field_offset);
+
+/**
+ * get_board_info_string - Read a string field from the board info region
+ *
+ * @flash_base:           Base address of the memory-mapped QSPI flash.
+ * @board_info_offset:    Offset to the start of the board info structure.
+ * @field_offset:         Offset to a specific field within the structure.
+ * @buf:                  Buffer to store the string.
+ * @len:                  Length of the buffer.
+ *
+ * Reads a string from flash_base + board_info_offset + field_offset into buf.
+ * Ensures the string is null-terminated.
+ *
+ * Example:
+ *   char model_string[MAX_STRING_LEN];
+ *   get_board_info_string(RZG2L_SPIROM_BASE, BOARD_INFO_QSPI_OFFSET, OFFSET_MODEL_STRING, model_string, sizeof(model_string));
+ */
+void get_board_info_string(uintptr_t flash_base, size_t board_info_offset, size_t field_offset, char *buf, size_t len);
+
+#endif /* BOARD_INFO_H */

--- a/plat/renesas/rz/common/rz_common.mk
+++ b/plat/renesas/rz/common/rz_common.mk
@@ -118,7 +118,8 @@ BL31_SOURCES	+=	lib/cpus/aarch64/cortex_a55.S					\
 include lib/xlat_tables_v2/xlat_tables.mk
 PLAT_BL_COMMON_SOURCES	+=	${XLAT_TABLES_LIB_SRCS}					\
 							plat/renesas/rz/common/plat_rz_common.c	\
-							plat/renesas/rz/common/drivers/scifa.S
+							plat/renesas/rz/common/board_info.c	\
+							plat/renesas/rz/common/drivers/scifa.S \
 
 ifneq (${ENABLE_STACK_PROTECTOR},0)
 PLAT_BL_COMMON_SOURCES	+=	plat/renesas/rz/common/rz_stack_protector.c


### PR DESCRIPTION
Add function to read board information from QSPI and pass it via registers to U-Boot.