### PR TITLE
styhead/rz cmn: add support for ATF boot using the FCONF on RZ/V2L-EVK.

### DIFF
--- a/fdts/r9a07g054l2-smarc.dts
+++ b/fdts/r9a07g054l2-smarc.dts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/*
+ * Device Tree Source for the RZ/V2L SMARC EVK board
+ *
+ * Copyright (C) 2025 Renesas Electronics Corp.
+ */
+
+/dts-v1/;
+
+/ {
+	compatible = "renesas,smarc-evk", "renesas,r9a07g054l2", "renesas,r9a07g054";
+	model = "Renesas SMARC EVK based on r9a07g054l2";
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	/* clock can be either from exclk or crystal oscillator (XIN/XOUT) */
+	extal_clk: extal {
+		compatible = "fixed-clock";
+		#clock-cells = <0x00>;
+		clock-frequency = <0x00>;
+		phandle = <0x03>;
+	};
+
+	sbc: soc {
+		compatible = "simple-bus";
+		#address-cells = <0x02>;
+		#size-cells = <0x02>;
+
+		scif0: serial@1004b800 {
+			compatible = "renesas,scif-r9a07g054";
+			reg = <0x00 0x1004b800 0x00 0x400>;
+			interrupt-names = "eri", "rxi", "txi", "bri", "dri", "tei";
+			clock-names = "fck";
+			dmas = <&dmac 0x4e79>, <&dmac 0x4e7a>;
+			dma-names = "tx", "rx";
+			power-domains = <&cpg>;
+			status = "disabled";
+		};
+
+		spi0: spi@10060000 {
+			compatible = "renesas,r9a07g054-rpc-if", "renesas,rzg2l-rpc-if";
+			reg = <0x00 0x10060000 0x00 0x10000>,
+			      <0x00 0x20000000 0x00 0x10000000>,
+			      <0x00 0x10070000 0x00 0x10000>;
+			reg-names = "regs", "dirmap", "wbuf";
+			power-domains = <&cpg>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "disabled";
+			spim_phycnt = <0x260>;
+			spim_phyoffset1 = <0x31511144>;
+			spim_phyoffset2 = <0x431>;
+			spim_cmncr = <0x155a200>;
+			spim_ssldr = <0x30303>;
+			spim_drcr = <0x1f0300>;
+			spim_drcmr = <0xeb0000>;
+			spim_drear = <0x0>;
+			spim_drenr = <0x202c700>;
+			spim_drdmcr = <0x9>;
+			spim_drdrenr = <0x0>;
+		};
+
+		cpg: clock-controller@11010000 {
+			compatible = "renesas,r9a07g054-cpg";
+			reg = <0 0x11010000 0 0x10000>;
+			clocks = <&extal_clk>;
+			clock-names = "extal";
+			#clock-cells = <2>;
+			#reset-cells = <1>;
+			#power-domain-cells = <0>;
+
+			divpl1_set = <0x00>;
+			divpl1_set_wen = <0x01>;
+			cpg_pll4_clk1 = <0xfae13203>;
+			cpg_pll4_clk2 = <0x81000>;
+			cpg_pll4_stby = <0x10001>;
+			cpg_pll6_clk1 = <0x3e83>;
+			cpg_pll6_clk2 = <0x82d02>;
+			cpg_pll6_stby = <0x10001>;
+		};
+
+		sysc: system-controller@11020000 {
+			compatible = "renesas,r9a07g054-sysc";
+			reg = <0 0x11020000 0 0x10000>;
+
+			syc_inck_hz = <24000000>;
+		};
+
+		pinctrl: pinctrl@11030000 {
+			compatible = "renesas,r9a07g054-pinctrl";
+			reg = <0 0x11030000 0 0x10000>, <0 0x110a0020 0 0x30>;
+
+			pfc_qspi0_iolh0a = 	<0x2020202>;
+			pfc_qspi0_pupd0a = 	<0x0000000>;
+			pfc_qspi0_sr0a 	 = 	<0x1010101>;
+			pfc_qspi1_iolh0b = 	<0x2020202>;
+			pfc_qspi1_pupd0b = 	<0x0000000>;
+			pfc_qspi1_sr0b 	 = 	<0x1010101>;
+			pfc_qspin_iolh0c = 	<0x0000002>;
+			pfc_qspin_pupd0c = 	<0x0000000>;
+			pfc_qspin_sr0c 	 = 	<0x0000001>;
+		};
+
+		ddr: memory@40000000 {
+			compatible = "renesas,r9a07g054-sdram";
+			reg = <0 0x40000000 0 0x10000>;
+
+			// DDRMC
+			ddrmc_r030 = <0x00000B02>;
+			ddrmc_r031 = <0x00000106>;
+			ddrmc_r032 = <0x11131C0D>;
+			ddrmc_r033 = <0x12001F15>;
+			ddrmc_r034 = <0x1D19140E>;
+			ddrmc_r035 = <0x17091B1A>;
+			ddrmc_r036 = <0x0A10160C>;
+			ddrmc_r037 = <0x0018051E>;
+			ddrmc_r038 = <0x00000000>;
+
+			// DDRPHY
+			ddrphy_setup_step1 = <0x00000000>;
+			ddrphy_setup_step2 = <0x14001816>;
+			ddrphy_setup_step3 = <0x00000001>;
+			ddrphy_setup_step4 = <0x010D0608>;
+			ddrphy_setup_step5 = <0x00000002>;
+			ddrphy_setup_step6 = <0x02190403>;
+			ddrphy_setup_step7 = <0x00000003>;
+			ddrphy_setup_step8 = <0x1705150B>;
+			ddrphy_setup_step9 = <0x00000004>;
+			ddrphy_setup_step10 = <0x13121110>;
+			ddrphy_setup_step11 = <0x00000005>;
+			ddrphy_setup_step12 = <0x07090F0E>;
+			ddrphy_setup_step13 = <0x00000006>;
+			ddrphy_setup_step14 = <0x1A1D0A1B>;
+			ddrphy_setup_step15 = <0x00000007>;
+			ddrphy_setup_step16 = <0x001E1C0C>;
+
+			// DDR_DENALI
+			ddr_denali_ctl_30 = <0x000001B8>;
+			ddr_denali_ctl_34 = <0x01C00255>;
+			ddr_denali_ctl_35 = <0x000001C0>;
+			ddr_denali_ctl_122 = <0x00010100>;
+			ddr_denali_ctl_123 = <0x00010100>;
+			ddr_denali_ctl_124 = <0x1FFF0000>;
+			ddr_denali_ctl_125 = <0x0003FF00>;
+		};
+
+		dmac: dma-controller@11820000 {
+			compatible = "renesas,r9a07g054-dmac",
+				     "renesas,rz-dmac";
+			reg = <0x00 0x11820000 0x00 0x10000>,
+			      <0x00 0x11830000 0x00 0x10000>;
+			interrupt-names = "error",
+					  "ch0", "ch1", "ch2", "ch3",
+					  "ch4", "ch5", "ch6", "ch7",
+					  "ch8", "ch9", "ch10", "ch11",
+					  "ch12", "ch13", "ch14", "ch15";
+			clock-names = "main", "register";
+			power-domains = <&cpg>;
+			reset-names = "arst", "rst_async";
+			#dma-cells = <0x01>;
+			dma-channels = <0x10>;
+			phandle = <0x01>;
+		};
+
+		sdhi0: mmc@11c00000 {
+			compatible = "renesas,sdhi-r9a07g054",
+				     "renesas,rcar-gen3-sdhi";
+			reg = <0x0 0x11c00000 0x00 0x10000>;
+			clock-names = "core", "clkh", "cd", "aclk";
+			power-domains = <&cpg>;
+			status = "disabled";
+		};
+
+		phyrst: usbphy-ctrl@11c40000 {
+			compatible = "renesas,r9a07g054-usbphy-ctrl",
+				     "renesas,rzg2l-usbphy-ctrl";
+			reg = <0x00 0x11c40000 0x00 0x10000>;
+			power-domains = <&cpg>;
+			#reset-cells = <1>;
+			status = "disabled";
+		};
+
+		wdt0: watchdog@12800800 {
+			compatible = "renesas,r9a07g054-wdt",
+				     "renesas,rzg2l-wdt";
+			reg = <0x00 0x12800800 0x00 0x400>;
+			clock-names = "pclk", "oscclk";
+			interrupt-names = "wdt", "perrout";
+			power-domains = <&cpg>;
+			status = "disabled";
+		};
+	};
+};

--- a/plat/renesas/rz/board/smarc_rzv2l/rz_board.mk
+++ b/plat/renesas/rz/board/smarc_rzv2l/rz_board.mk
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2021, Renesas Electronics Corporation. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+DDR_SOURCES +=  plat/renesas/rz/soc/${PLAT}/drivers/ddr/ddr_v2l.c \
+				plat/renesas/rz/soc/${PLAT}/drivers/ddr/param_mc_C-011_D4-01-1.c \
+				plat/renesas/rz/common/drivers/ddr/param_swizzle_v2l.c
+
+DDR_PLL4    := 1600
+$(eval $(call add_define,DDR_PLL4))
+
+# Default Device tree
+DTB_FILE_NAME		?=	r9a07g054l2-smarc

--- a/plat/renesas/rz/common/drivers/ddr/param_swizzle_v2l.c
+++ b/plat/renesas/rz/common/drivers/ddr/param_swizzle_v2l.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020-2022, Renesas Electronics Corporation. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * This code was generated with RZ/G2L, G2UL, Five, A3UL DDR config generation tool v3.0.1
+ */
+
+#include <stdint.h>
+#include <ddr_internal.h>
+
+const uint32_t mc_odt_pins_tbl[4] = {
+	0x00000001	,
+	0x00000000	,
+	0x00000000	,
+	0x00000000
+};
+
+const uint32_t mc_mr1_tbl[2] = {
+	0x00000706	,
+	0x00000100
+};
+
+const uint32_t mc_mr2_tbl[2] = {
+	0x00000E00	,
+	0x00000000
+};
+
+const uint32_t mc_mr5_tbl[2] = {
+	0x000001C0	,
+	0x000001C0
+};
+
+const uint32_t mc_mr6_tbl[2] = {
+	0x0000007F	,
+	0x0000000F
+};
+
+const uint32_t mc_phy_settings_tbl[MC_PHYSET_NUM][2] = {
+	{DDRMC_R040,	0x57630BB8	},
+	{DDRMC_R041,	0x00002828	},
+	{DDRMC_R042,	0x00003C22	},
+	{DDRMC_R043,	0x00102611	}
+};
+
+const uint32_t swizzle_mc_tbl[SWIZZLE_MC_NUM][2] = {
+	{DDRMC_R030},
+	{DDRMC_R031},
+	{DDRMC_R032},
+	{DDRMC_R033},
+	{DDRMC_R034},
+	{DDRMC_R035},
+	{DDRMC_R036},
+	{DDRMC_R037},
+	{DDRMC_R038}
+};
+
+const uint32_t swizzle_phy_tbl[SIZZLE_PHY_NUM][2] = {
+	{DDRPHY_R29},
+	{DDRPHY_R11},
+	{DDRPHY_R29},
+	{DDRPHY_R11},
+	{DDRPHY_R29},
+	{DDRPHY_R11},
+	{DDRPHY_R29},
+	{DDRPHY_R11},
+	{DDRPHY_R29},
+	{DDRPHY_R11},
+	{DDRPHY_R29},
+	{DDRPHY_R11},
+	{DDRPHY_R29},
+	{DDRPHY_R11},
+	{DDRPHY_R29},
+	{DDRPHY_R11}
+};

--- a/plat/renesas/rz/soc/g2l/platform.mk
+++ b/plat/renesas/rz/soc/g2l/platform.mk
@@ -31,6 +31,7 @@ BOARD_NAME := $(shell echo $(BOARD) | awk -F'_' '{print $$1}')
 BL2_IMAGE  := ${BUILD_PLAT}/bl2.bin
 BL2_DTB    := ${BUILD_PLAT}/fdts/${DTB_FILE_NAME}.dtb
 BL2_OUTPUT := ${BUILD_PLAT}/bl2_with_dtb-${BOARD_NAME}.bin
+BL2_FINAL  := ${BUILD_PLAT}/bl2.bin
 
 ifeq (${TRUSTED_BOARD_BOOT}, 0)
 BL2_BASE := 0x12000
@@ -70,4 +71,4 @@ bl2_with_dtb: ${BL2_IMAGE} ${BL2_DTB}
 	echo "INFO: Total merged size  : $$MERGED_SIZE bytes"; \
 	echo "INFO: BL2 limit size     : 0x$$(printf '%X' $$BL2_BINARY_LIMIT_SIZE)"; \
 	echo "INFO: DTB base address   : 0x$$(printf '%X' $$DTB_BASE)"
-	xxd ${BL2_OUTPUT} > bl2_with_dtb.hex
+	mv -f ${BL2_OUTPUT} ${BL2_FINAL}

--- a/plat/renesas/rz/soc/v2l/platform.mk
+++ b/plat/renesas/rz/soc/v2l/platform.mk
@@ -11,3 +11,64 @@ PLAT_INCLUDES	+=	-Iplat/renesas/rz/soc/v2l/include
 
 DDR_SOURCES += plat/renesas/rz/soc/v2l/drivers/ddr/ddr_v2l.c
 
+include lib/libfdt/libfdt.mk
+
+BL2_SOURCES		+=	lib/fconf/fconf_dyn_cfg_getter.c 	\
+					plat/renesas/rz/common/rz_dt.c		\
+					plat/renesas/rz/common/rz_fconf.c
+FDT_SOURCES		:=	$(addprefix ${BUILD_PLAT}/fdts/, $(patsubst %.dtb,%.dts,$(DTB_FILE_NAME).dtb))
+
+# Create DTB file for BL2
+${BUILD_PLAT}/fdts/${DTB_FILE_NAME}.dts: fdts/${DTB_FILE_NAME}.dts| ${BUILD_PLAT} fdt_dirs
+	cp $< $@
+
+${BUILD_PLAT}/fdts/${DTB_FILE_NAME}.dtb: fdts/${DTB_FILE_NAME}.dts | ${BUILD_PLAT} fdt_dirs
+
+# Define paths for the BL2 binary and DTB
+BOARD_NAME := $(shell echo $(BOARD) | awk -F'_' '{print $$1}')
+
+# Define the input file and target for the merged binary
+BL2_IMAGE  := ${BUILD_PLAT}/bl2.bin
+BL2_DTB    := ${BUILD_PLAT}/fdts/${DTB_FILE_NAME}.dtb
+BL2_OUTPUT := ${BUILD_PLAT}/bl2_with_dtb-${BOARD_NAME}.bin
+BL2_FINAL  := ${BUILD_PLAT}/bl2.bin
+
+ifeq (${TRUSTED_BOARD_BOOT}, 0)
+BL2_BASE := 0x12000
+else
+BL2_BASE := 0x13000
+endif
+
+SRAM_LIMIT := $(shell printf "%d" 0x1D000)
+BL2_BIN_LIMIT := $(shell grep 'RZG2L_BINARY_LIMIT_SIZE' plat/renesas/rz/common/include/rzg2l_def.h | sed -E 's/.*\((0x[0-9A-Fa-f]+)\).*/\1/')
+BL2_BIN_LIMIT_DEC := $(shell printf "%d" $(BL2_BIN_LIMIT))
+
+# Rule for creating the merged BL2 with DTB file
+bl2_with_dtb: ${BL2_IMAGE} ${BL2_DTB}
+	@echo "Embedding DTB into BL2 with dynamic padding..."
+	@BL2_SIZE=$$(wc -c < ${BL2_IMAGE} | awk '{print $$1}'); \
+	PADDING=$$(($(BL2_BIN_LIMIT_DEC) - $$BL2_SIZE)); \
+	if [ $$PADDING -lt 0 ]; then \
+		echo "Error: BL2 size exceeds available space before BL2_BIN_LIMIT ($(BL2_BIN_LIMIT_DEC))"; \
+		echo "INFO: BL2 size : $$BL2_SIZE bytes"; \
+		exit 1; \
+	fi; \
+	DTB_SIZE=$$(wc -c < ${BL2_DTB} | awk '{print $$1}'); \
+	cat ${BL2_IMAGE} > bl2_padded.bin; \
+	dd if=/dev/zero bs=1 count=$$PADDING >> bl2_padded.bin; \
+	cat bl2_padded.bin ${BL2_DTB} > ${BL2_OUTPUT}; \
+	rm -f bl2_padded.bin; \
+	MERGED_SIZE=$$(wc -c < ${BL2_OUTPUT} | awk '{print $$1}'); \
+	if [ $$MERGED_SIZE -gt $(SRAM_LIMIT) ]; then \
+		echo "Error: Total size of BL2 + padding + DTB ($$MERGED_SIZE bytes) exceeds SRAM limit ($(SRAM_LIMIT) bytes)"; \
+		exit 1; \
+	fi; \
+	BL2_BINARY_LIMIT_SIZE=$$(($$BL2_SIZE + $$PADDING)); \
+	DTB_BASE=$$(( $(BL2_BASE) + $$BL2_BINARY_LIMIT_SIZE )); \
+	echo "INFO: Created merged binary: ${BL2_OUTPUT}"; \
+	echo "INFO: BL2 size           : $$BL2_SIZE bytes"; \
+	echo "INFO: DTB size           : $$DTB_SIZE bytes"; \
+	echo "INFO: Total merged size  : $$MERGED_SIZE bytes"; \
+	echo "INFO: BL2 limit size     : 0x$$(printf '%X' $$BL2_BINARY_LIMIT_SIZE)"; \
+	echo "INFO: DTB base address   : 0x$$(printf '%X' $$DTB_BASE)"
+	mv -f ${BL2_OUTPUT} ${BL2_FINAL}


### PR DESCRIPTION
Changes include:
- Add support for ATF boot using the FCONF framework and device tree on RZ/V2L-EVK.
- Rename bl2_with_dtb to bl2.bin to simplify merging and integration.