### PR TITLE
plat: renesas: rz: pass soc_id instead of revision

### DIFF
--- a/plat/renesas/rz/common/bl31_plat_setup.c
+++ b/plat/renesas/rz/common/bl31_plat_setup.c
@@ -196,16 +196,16 @@ void bl31_platform_setup(void)
 		pwrc_setup();
 	}
 
-	/* Read model and revision id from QSPI */
+	/* Read model id from QSPI */
 	uint32_t model = get_board_info_u32(RZG2L_SPIROM_BASE, RZG2L_SPIROM_SIZE, bl31_board_cfg[soc_id].board_info_qspi_offset, OFFSET_MODEL_ID);
-	uint32_t revision = get_board_info_u32(RZG2L_SPIROM_BASE, RZG2L_SPIROM_SIZE, bl31_board_cfg[soc_id].board_info_qspi_offset, OFFSET_REVISION);
 
 	/* Get entry point info for BL33 */
 	entry_point_info_t *bl33_ep_info = bl31_plat_get_next_image_ep_info(NON_SECURE);
 
+	/* Pass model ID and SoC ID to U-Boot via registers */
 	if (bl33_ep_info != NULL) {
 		bl33_ep_info->args.arg2 = model;
-		bl33_ep_info->args.arg3 = revision;
+		bl33_ep_info->args.arg3 = soc_id;
 	}
 }
 


### PR DESCRIPTION
Pass the SoC ID from the device tree property (soc_id) to U-Boot via registers, replacing the previous use of the revision value.