### PR TITLE
rz-cmn: add eMMC support and fix init PFC data

### DIFF
--- a/plat/renesas/rz/common/bl31_plat_setup.c
+++ b/plat/renesas/rz/common/bl31_plat_setup.c
@@ -10,6 +10,7 @@
 #include <common/bl_common.h>
 #include <lib/xlat_tables/xlat_tables_compat.h>
 #include <plat/common/common_def.h>
+#include <sys.h>
 
 #include <scifa.h>
 #include <plat_tzc_def.h>
@@ -68,6 +69,13 @@ bl31_board_cfg_t bl31_board_cfg[] = {
 		.tzc_asram_base    = RZG2L_TZC_ASRAM_BASE,
 		.syc_timer_base    = RZG2L_SYC_BASE,
 		.sysc_base         = RZG2L_SYSC_BASE,
+		.sysc_lsi_mode_reg_offset = 0x00000A00,
+		.sysc_lsi_mode_mask = 0x0F,
+		.sysc_boot_mode_esd = 0,
+		.sysc_boot_mode_emmc_1_8 = 1,
+		.sysc_boot_mode_emmc_3_3 = 2,
+		.sysc_boot_mode_spi_1_8 = 3,
+		.sysc_boot_mode_spi_3_3 = 4,
 		.cpg_base          = RZG2L_CPG_BASE,
 		.gicd_base         = RZG2L_GICD_BASE,
 		.gicr_base         = RZG2L_GICR_BASE,
@@ -89,6 +97,13 @@ bl31_board_cfg_t bl31_board_cfg[] = {
 		.tzc_asram_base    = RZG2L_TZC_ASRAM_BASE,
 		.syc_timer_base    = RZG2L_SYC_BASE,
 		.sysc_base         = RZG2L_SYSC_BASE,
+		.sysc_lsi_mode_reg_offset = 0x00000A00,
+		.sysc_lsi_mode_mask = 0x0F,
+		.sysc_boot_mode_esd = 0,
+		.sysc_boot_mode_emmc_1_8 = 1,
+		.sysc_boot_mode_emmc_3_3 = 2,
+		.sysc_boot_mode_spi_1_8 = 3,
+		.sysc_boot_mode_spi_3_3 = 4,
 		.cpg_base          = RZG2L_CPG_BASE,
 		.gicd_base         = RZG2L_GICD_BASE,
 		.gicr_base         = RZG2L_GICR_BASE,
@@ -110,6 +125,13 @@ bl31_board_cfg_t bl31_board_cfg[] = {
 		.tzc_asram_base    = RZV2H_TZC400_A55_BASE,
 		.syc_timer_base    = RZV2H_SYC_BASE,
 		.sysc_base         = RZV2H_SYSC_BASE,
+		.sysc_lsi_mode_reg_offset = 0x00000300,
+		.sysc_lsi_mode_mask = 0x7,
+		.sysc_boot_mode_esd = 0,
+		.sysc_boot_mode_emmc_1_8 = 5,
+		.sysc_boot_mode_emmc_3_3 = 1,
+		.sysc_boot_mode_spi_1_8 = 6,
+		.sysc_boot_mode_spi_3_3 = 2,
 		.cpg_base          = RZV2H_CPG_BASE,
 		.gicd_base         = RZV2H_GICD_BASE,
 		.gicr_base         = RZV2H_GICR_BASE,
@@ -199,8 +221,33 @@ void bl31_platform_setup(void)
 		pwrc_setup();
 	}
 
-	/* Read model id from QSPI */
-	uint32_t model = get_board_info_u32(RZG2L_SPIROM_BASE, RZG2L_SPIROM_SIZE, bl31_board_cfg[soc_id].board_info_qspi_offset, OFFSET_MODEL_ID);
+	uint32_t model = 0;
+	boot_mode_t boot_mode = sys_get_boot_mode();
+
+	if (boot_mode == SYS_BOOT_MODE_SPI_1_8 ||
+		boot_mode == SYS_BOOT_MODE_SPI_3_3) {
+		/* Read model and revision id from QSPI */
+		model = get_board_info_u32(RZG2L_SPIROM_BASE, RZG2L_SPIROM_SIZE, bl31_board_cfg[soc_id].board_info_qspi_offset, OFFSET_MODEL_ID);
+	} else if  (boot_mode == SYS_BOOT_MODE_EMMC_1_8 || boot_mode == SYS_BOOT_MODE_EMMC_3_3) {
+
+		const volatile struct board_mb *mb = (const volatile struct board_mb *)(BOARD_MB_ADDR);
+
+		if (mb->magic == BOARD_MB_MAGIC && mb->size == sizeof(platform_desc_t)) {
+			/* Copy out of volatile mailbox to a local buffer */
+			platform_desc_t d;
+			memcpy(&d, (const void *)&mb->desc, sizeof(d));
+
+			model = d.model_id;
+
+			NOTICE("BL31: boardinfo: model=0x%x\"\n", model);
+		} else {
+			NOTICE("BL31: boardinfo: mailbox absent/invalid at 0x%lx\n",
+				(unsigned long)BOARD_MB_ADDR);
+		}
+	} else {
+		ERROR("BL31: Unknown boot mode %d\n", boot_mode);
+		panic();
+	}
 
 	/* Get entry point info for BL33 */
 	entry_point_info_t *bl33_ep_info = bl31_plat_get_next_image_ep_info(NON_SECURE);

--- a/plat/renesas/rz/common/board_info.c
+++ b/plat/renesas/rz/common/board_info.c
@@ -10,6 +10,11 @@
 #include <lib/mmio.h>
 #include <assert.h>
 #include <board_info.h>
+#include <drivers/io/io_driver.h>
+#include <string.h>
+#include <emmc_def.h>
+
+extern void flush_dcache_range(uintptr_t addr, size_t size);
 
 /**
  * get_board_info_field - Read a 32-bit field from the board info region
@@ -40,6 +45,86 @@ uint32_t get_board_info_u32(uintptr_t flash_map_base, uintptr_t flash_size, size
 	}
 
 	return mmio_read_32(addr);
+}
+
+/**
+ * bl2_emmc_load_boardinfo() - Load board identification data from eMMC
+ *
+ * This routine reads a small board-info structure
+ * from a fixed sector window in the eMMC and publishes it
+ * into the SRAM mailbox shared with later stages (BL31/BL33).
+ *
+ * Return: 0 on success, <0 on failure (partition select, open, or read).
+ *
+ * Notes:
+ * - The mailbox is used by BL31 to determine the board variant.
+ */
+int bl2_emmc_load_boardinfo(uintptr_t emmc_handle)
+{
+	platform_desc_t tmp;
+	size_t bytes_read = 0;
+	int rc;
+	uintptr_t h = 0;
+
+	/* Compute byte window from eMMC defines of board identification */
+	const size_t bi_start_lba = BOARD_INFO_EMMC_SECTOR_START;
+	const size_t bi_sector_sz = BOARD_INFO_EMMC_SECTOR_SIZE;
+	const size_t bi_sector_cnt = BOARD_INFO_EMMC_SECTOR_COUNT;
+	const size_t bi_window_size = bi_sector_cnt * bi_sector_sz;
+	const size_t bi_offset = bi_start_lba * bi_sector_sz;
+	const size_t read_len = (sizeof(tmp) <= bi_window_size) ? sizeof(tmp) : bi_window_size;
+
+	const io_block_spec_t spec = {
+		.offset = bi_offset,
+		.length = read_len,
+	};
+
+	/* Select eMMC partition 1 */
+	if (emmc_select_partition(PARTITION_ID_BOOT_1) != EMMC_SUCCESS) {
+		ERROR("BL2: select BOOT#1 failed\n");
+		panic();
+	}
+
+	/* Open the I/O window and read data */
+	rc = io_open(emmc_handle, (uintptr_t)&spec, &h);
+	if (rc) {
+		ERROR("BL2: boardinfo(emmc) open rc=%d\n", rc);
+		goto fail_restore_user;
+	}
+
+	rc = io_read(h, (uintptr_t)&tmp, read_len, &bytes_read);
+	io_close(h);
+
+	if (rc || bytes_read != read_len) {
+		ERROR("BL2: boardinfo(emmc) read rc=%d bytes=%zu (exp=%zu)\n",
+			rc, bytes_read, read_len);
+		rc = (rc) ? rc : -1;
+		goto fail_restore_user;
+	}
+
+	/* Zero-pad if only a partial read occurred */
+	if (read_len < sizeof(tmp)) {
+		memset((uint8_t *)&tmp + read_len, 0, sizeof(tmp) - read_len);
+	}
+
+	/* Publish to SRAM mailbox */
+	struct board_mb *mb = (struct board_mb *)BOARD_MB_ADDR;
+	mb->desc  = tmp;
+	mb->size  = sizeof(tmp);
+	mb->magic = BOARD_MB_MAGIC;
+	flush_dcache_range((uintptr_t)mb, sizeof(*mb));
+
+	NOTICE("BL2: boardinfo(emmc) model=0x%x\"\n",
+		mb->desc.model_id);
+
+	/* Restore eMMC partition to USER so BL33 sees defaults */
+	(void)emmc_select_partition(PARTITION_ID_USER);
+	return 0;
+
+fail_restore_user:
+	/* Restore USER partition */
+	(void)emmc_select_partition(PARTITION_ID_USER);
+	return rc ? rc : -1;
 }
 
 /**
@@ -112,4 +197,3 @@ void get_chipid(uintptr_t otp_base, uint32_t *chipid)
     chipid[2] = mmio_read_32(otp_base + 0x8);
     chipid[3] = mmio_read_32(otp_base + 0xC);
 }
-

--- a/plat/renesas/rz/common/drivers/pfc.c
+++ b/plat/renesas/rz/common/drivers/pfc.c
@@ -14,6 +14,7 @@
 #include <lib/fconf/fconf.h>
 #include <lib/libfdt/libfdt.h>
 #include <rz_fconf.h>
+#include <common/debug.h>
 
 const struct pfc_config_t * g_pfc_fconf_cfg;
 
@@ -202,6 +203,7 @@ static void pfc_sd_setup(void)
 {
 	int      cnt;
 	int i, j = 0;
+	uint64_t temp = 0;
 	const void *fdt = (const void *)(uintptr_t)dtb_base;
 	int len;
 
@@ -211,35 +213,70 @@ static void pfc_sd_setup(void)
 
 	const fdt32_t *prop = fdt_getprop(fdt, g_pfc_fconf_cfg->pfc_node, "pfc_sd_reg_tbl", &len);
 	for (i = 0; i < (len / sizeof(uint32_t)); i += 18, j++) {
-		/* PMC */
-		pfc_sd_reg_tbl[j].pmc.flg = fdt32_to_cpu(prop[i]);
-		pfc_sd_reg_tbl[j].pmc.reg = fdt32_to_cpu(prop[i + 1]);
-		pfc_sd_reg_tbl[j].pmc.val = fdt32_to_cpu(prop[i + 2]);
+		if (j == 1) {
+			/* PMC */
+			pfc_sd_reg_tbl[j].pmc.flg = fdt32_to_cpu(prop[i]);
+			pfc_sd_reg_tbl[j].pmc.reg = fdt32_to_cpu(prop[i + 1]);
+			pfc_sd_reg_tbl[j].pmc.val = fdt32_to_cpu(prop[i + 2]);
 
-		/* PFC */
-		pfc_sd_reg_tbl[j].pfc.flg = fdt32_to_cpu(prop[i + 3]);
-		pfc_sd_reg_tbl[j].pfc.reg = fdt32_to_cpu(prop[i + 4]);
-		pfc_sd_reg_tbl[j].pfc.val = fdt32_to_cpu(prop[i + 5]);
+			/* PFC */
+			pfc_sd_reg_tbl[j].pfc.flg = fdt32_to_cpu(prop[i + 3]);
+			pfc_sd_reg_tbl[j].pfc.reg = fdt32_to_cpu(prop[i + 4]);
+			pfc_sd_reg_tbl[j].pfc.val = fdt32_to_cpu(prop[i + 5]);
 
-		/* IOLH */
-		pfc_sd_reg_tbl[j].iolh.flg = fdt32_to_cpu(prop[i + 6]);
-		pfc_sd_reg_tbl[j].iolh.reg = fdt32_to_cpu(prop[i + 7]);
-		pfc_sd_reg_tbl[j].iolh.val = fdt32_to_cpu(prop[i + 8]);
+			/* IOLH */
+			pfc_sd_reg_tbl[j].iolh.flg = fdt32_to_cpu(prop[i + 6]);
+			pfc_sd_reg_tbl[j].iolh.reg = fdt32_to_cpu(prop[i + 7]);
+			temp = (uint64_t)fdt32_to_cpu(prop[i + 8]);
+			pfc_sd_reg_tbl[j].iolh.val = (temp << 32) | temp;
 
-		/* PUPD */
-		pfc_sd_reg_tbl[j].pupd.flg = fdt32_to_cpu(prop[i + 9]);
-		pfc_sd_reg_tbl[j].pupd.reg = fdt32_to_cpu(prop[i + 10]);
-		pfc_sd_reg_tbl[j].pupd.val = fdt32_to_cpu(prop[i + 11]);
+			/* PUPD */
+			pfc_sd_reg_tbl[j].pupd.flg = fdt32_to_cpu(prop[i + 9]);
+			pfc_sd_reg_tbl[j].pupd.reg = fdt32_to_cpu(prop[i + 10]);
+			pfc_sd_reg_tbl[j].pupd.val = fdt32_to_cpu(prop[i + 11]);
 
-		/* SR */
-		pfc_sd_reg_tbl[j].sr.flg = fdt32_to_cpu(prop[i + 12]);
-		pfc_sd_reg_tbl[j].sr.reg = fdt32_to_cpu(prop[i + 13]);
-		pfc_sd_reg_tbl[j].sr.val = fdt32_to_cpu(prop[i + 14]);
+			/* SR */
+			pfc_sd_reg_tbl[j].sr.flg = fdt32_to_cpu(prop[i + 12]);
+			pfc_sd_reg_tbl[j].sr.reg = fdt32_to_cpu(prop[i + 13]);
+			temp = (uint64_t)fdt32_to_cpu(prop[i + 14]);
+			pfc_sd_reg_tbl[j].sr.val = (temp << 32) | temp;
 
-		/* IEN */
-		pfc_sd_reg_tbl[j].ien.flg = fdt32_to_cpu(prop[i + 15]);
-		pfc_sd_reg_tbl[j].ien.reg = fdt32_to_cpu(prop[i + 16]);
-		pfc_sd_reg_tbl[j].ien.val = fdt32_to_cpu(prop[i + 17]);
+			/* IEN */
+			pfc_sd_reg_tbl[j].ien.flg = fdt32_to_cpu(prop[i + 15]);
+			pfc_sd_reg_tbl[j].ien.reg = fdt32_to_cpu(prop[i + 16]);
+			temp = (uint64_t)fdt32_to_cpu(prop[i + 17]);
+			pfc_sd_reg_tbl[j].ien.val = (temp << 32) | temp;
+		} else {
+			/* PMC */
+			pfc_sd_reg_tbl[j].pmc.flg = fdt32_to_cpu(prop[i]);
+			pfc_sd_reg_tbl[j].pmc.reg = fdt32_to_cpu(prop[i + 1]);
+			pfc_sd_reg_tbl[j].pmc.val = fdt32_to_cpu(prop[i + 2]);
+
+			/* PFC */
+			pfc_sd_reg_tbl[j].pfc.flg = fdt32_to_cpu(prop[i + 3]);
+			pfc_sd_reg_tbl[j].pfc.reg = fdt32_to_cpu(prop[i + 4]);
+			pfc_sd_reg_tbl[j].pfc.val = fdt32_to_cpu(prop[i + 5]);
+
+			/* IOLH */
+			pfc_sd_reg_tbl[j].iolh.flg = fdt32_to_cpu(prop[i + 6]);
+			pfc_sd_reg_tbl[j].iolh.reg = fdt32_to_cpu(prop[i + 7]);
+			pfc_sd_reg_tbl[j].iolh.val = fdt32_to_cpu(prop[i + 8]);
+
+			/* PUPD */
+			pfc_sd_reg_tbl[j].pupd.flg = fdt32_to_cpu(prop[i + 9]);
+			pfc_sd_reg_tbl[j].pupd.reg = fdt32_to_cpu(prop[i + 10]);
+			pfc_sd_reg_tbl[j].pupd.val = fdt32_to_cpu(prop[i + 11]);
+
+			/* SR */
+			pfc_sd_reg_tbl[j].sr.flg = fdt32_to_cpu(prop[i + 12]);
+			pfc_sd_reg_tbl[j].sr.reg = fdt32_to_cpu(prop[i + 13]);
+			pfc_sd_reg_tbl[j].sr.val = fdt32_to_cpu(prop[i + 14]);
+
+			/* IEN */
+			pfc_sd_reg_tbl[j].ien.flg = fdt32_to_cpu(prop[i + 15]);
+			pfc_sd_reg_tbl[j].ien.reg = fdt32_to_cpu(prop[i + 16]);
+			pfc_sd_reg_tbl[j].ien.val = fdt32_to_cpu(prop[i + 17]);
+		}
 	}
 
 	for (cnt = 0; cnt < ARRAY_SIZE(pfc_sd_reg_tbl); cnt++) {

--- a/plat/renesas/rz/common/drivers/sys.c
+++ b/plat/renesas/rz/common/drivers/sys.c
@@ -11,8 +11,10 @@
 #include <common/debug.h>
 #include <lib/fconf/fconf.h>
 #include <rz_fconf.h>
+#include <rz_private.h>
 
-
+extern bl31_board_cfg_t bl31_board_cfg[];
+extern uint32_t soc_id;
 
 bool sys_is_resume_reboot(void)
 {
@@ -25,11 +27,13 @@ bool sys_is_resume_reboot(void)
 
 boot_mode_t sys_get_boot_mode(void)
 {
+	boot_mode_t boot_mode = 0;
+
+#if IMAGE_BL2
 	/* Initialize global SYSC config from DTB.  */
 	const struct sysc_config_t * g_sysc_fconf_cfg = sysc_config_getter();
 
-	uint32_t stat_md_boot = mmio_read_32(g_sysc_fconf_cfg->sysc_base + g_sysc_fconf_cfg->sysc_lsi_mode_reg_offset) & g_sysc_fconf_cfg->sysc_lsi_mode_mask;
-	boot_mode_t boot_mode = 0;
+	uint32_t stat_md_boot = mmio_read_32(g_sysc_fconf_cfg->sysc_base + g_sysc_fconf_cfg->sysc_lsi_mode_reg_offset) & g_sysc_fconf_cfg->sysc_lsi_mode_mask;	
 
 	if (stat_md_boot == g_sysc_fconf_cfg->sysc_boot_mode_esd) {
 		boot_mode = SYS_BOOT_MODE_ESD;
@@ -42,6 +46,20 @@ boot_mode_t sys_get_boot_mode(void)
 	} else if (stat_md_boot == g_sysc_fconf_cfg->sysc_boot_mode_spi_3_3) {
 		boot_mode = SYS_BOOT_MODE_SPI_3_3;
 	}
+#elif IMAGE_BL31
+	uint32_t stat_md_boot = mmio_read_32(bl31_board_cfg[soc_id].sysc_base + bl31_board_cfg[soc_id].sysc_lsi_mode_reg_offset) & bl31_board_cfg[soc_id].sysc_lsi_mode_mask;
 
+	if (stat_md_boot == bl31_board_cfg[soc_id].sysc_boot_mode_esd) {
+		boot_mode = SYS_BOOT_MODE_ESD;
+	} else if (stat_md_boot == bl31_board_cfg[soc_id].sysc_boot_mode_emmc_1_8) {
+		boot_mode = SYS_BOOT_MODE_EMMC_1_8;
+	} else if (stat_md_boot == bl31_board_cfg[soc_id].sysc_boot_mode_emmc_3_3) {
+		boot_mode = SYS_BOOT_MODE_EMMC_3_3;
+	} else if (stat_md_boot == bl31_board_cfg[soc_id].sysc_boot_mode_spi_1_8) {
+		boot_mode = SYS_BOOT_MODE_SPI_1_8;
+	} else if (stat_md_boot == bl31_board_cfg[soc_id].sysc_boot_mode_spi_3_3) {
+		boot_mode = SYS_BOOT_MODE_SPI_3_3;
+	}
+#endif
 	return boot_mode;
 }

--- a/plat/renesas/rz/common/include/board_info.h
+++ b/plat/renesas/rz/common/include/board_info.h
@@ -5,11 +5,20 @@
 #include <stddef.h>
 #include <rzg2l_def.h>
 
+/* Board information magic in SRAM  */
+#define BOARD_MB_MAGIC  0x424D4249u
+#define BOARD_MB_ADDR   (RZG2L_BOOTINFO_BASE + 0x800)
+
 /* Offset range of board information within the QSPI flash region */
 #define BOARD_INFO_QSPI_OFFSET U(0x1C700)
 #define BOARD_INFO_QSPI_END    U(0x1CF0F)
 
 #define MAX_STRING_LEN           256
+
+/* Offset range of board information within the eMMC flash region */
+#define BOARD_INFO_EMMC_SECTOR_START U(250)
+#define BOARD_INFO_EMMC_SECTOR_COUNT U(5)
+#define BOARD_INFO_EMMC_SECTOR_SIZE  U(512)
 
 /* Offsets for various fields inside the board info region */
 #define OFFSET_MODEL_ID          0x00
@@ -25,6 +34,22 @@
 #define RZ_SOC_RZG2L            0x01
 #define RZ_SOC_RZV2L            0x02
 #define RZ_SOC_RZV2H            0x03
+
+/* 
+ * Platform descriptor structure.
+ * - Packed to ensure no padding is added by the compiler,
+ *   so the memory layout is consistent when exchanged between components.
+ */
+typedef struct __attribute__((packed)) platform_desc {
+    uint32_t model_id;
+} platform_desc_t;
+
+/* mailbox placed in SRAM */
+struct board_mb {
+    uint32_t magic;
+    uint32_t size;
+    platform_desc_t desc;
+};
 
 /**
  * get_board_info_u32 - Read a 32-bit field from the board info region
@@ -56,6 +81,20 @@ uint32_t get_board_info_u32(uintptr_t flash_map_base, uintptr_t flash_size, size
  *   get_board_info_string(RZG2L_SPIROM_BASE, BOARD_INFO_QSPI_OFFSET, OFFSET_MODEL_STRING, model_string, sizeof(model_string));
  */
 void get_board_info_string(uintptr_t flash_base, size_t board_info_offset, size_t field_offset, char *buf, size_t len);
+
+/**
+ * bl2_emmc_load_boardinfo() - Load board identification data from eMMC
+ *
+ * This routine reads a small board-info structure
+ * from a fixed sector window in the eMMC and publishes it
+ * into the SRAM mailbox shared with later stages (BL31/BL33).
+ *
+ * Return: 0 on success, <0 on failure (partition select, open, or read).
+ *
+ * Notes:
+ * - The mailbox is used by BL31 to determine the board variant.
+ */
+int bl2_emmc_load_boardinfo(uintptr_t sd_handle);
 
 /**
  * get_chipid - Read the 128-bit Chip ID from OTP registers

--- a/plat/renesas/rz/common/include/rz_private.h
+++ b/plat/renesas/rz/common/include/rz_private.h
@@ -52,6 +52,13 @@ typedef struct {
 	uint32_t    tzc_asram_base;
 	uint32_t    syc_timer_base;
 	uint32_t    sysc_base;
+	uint32_t	sysc_lsi_mode_reg_offset;
+	uint32_t	sysc_lsi_mode_mask;
+	uint32_t	sysc_boot_mode_esd;
+	uint32_t	sysc_boot_mode_emmc_1_8;
+	uint32_t	sysc_boot_mode_emmc_3_3;
+	uint32_t	sysc_boot_mode_spi_1_8;
+	uint32_t	sysc_boot_mode_spi_3_3;
 	uint32_t    cpg_base;
 	uint32_t    gicd_base;
 	uint32_t    gicr_base;

--- a/plat/renesas/rz/common/plat_storage.c
+++ b/plat/renesas/rz/common/plat_storage.c
@@ -336,6 +336,7 @@ void rz_io_setup(void)
 				(uintptr_t) &emmc_block_spec,
 				&open_emmcdrv};
 		policies[FIP_IMAGE_ID] = emmc_fip_policy;
+		(void)bl2_emmc_load_boardinfo(emmcdrv_dev_handle);
 	} else {
 		panic();
 	}

--- a/plat/renesas/rz/common/rz_common.mk
+++ b/plat/renesas/rz/common/rz_common.mk
@@ -171,7 +171,7 @@ BL31_SOURCES			+=	plat/common/plat_gicv3.c								\
 							plat/renesas/rz/common/rz_plat_sip_handler.c			\
 							plat/renesas/rz/common/rz_sip_svc.c						\
 							plat/renesas/rz/common/board_info.c						\
-							${GICV3_SOURCES}
+							${GICV3_SOURCES}										\
 
 ifneq (${TRUSTED_BOARD_BOOT},0)
 


### PR DESCRIPTION
Changes include:
- Retrieve board identification from eMMC flash
- Fix PFC init data obtained from the device tree