### PR TITLE
renesas: rz-cmn: Fix CPG setting for DDR reset issue in DRP-AI

### DIFF
--- a/fdts/r9a07g044l2-smarc.dts
+++ b/fdts/r9a07g044l2-smarc.dts
@@ -94,6 +94,7 @@
 			cpg_selector_on_off = <1>;
 			cpg_early_setup = <1>;
 			cpg_mstop_setup = <0>;
+			cpg_rst_ddr_opt = <0x00000000>;
 
 			cpg_clk_on_tbl = <
 				0x0504 0x00030000

--- a/fdts/r9a07g054l2-smarc.dts
+++ b/fdts/r9a07g054l2-smarc.dts
@@ -94,6 +94,7 @@
 			cpg_selector_on_off = <1>;
 			cpg_early_setup = <1>;
 			cpg_mstop_setup = <0>;
+			cpg_rst_ddr_opt = <0x00000020>;
 
 			cpg_clk_on_tbl = <
 				0x0504 0x00030000

--- a/fdts/rs-g2l100.dts
+++ b/fdts/rs-g2l100.dts
@@ -91,6 +91,7 @@
 			cpg_selector_on_off = <1>;
 			cpg_early_setup = <1>;
 			cpg_mstop_setup = <0>;
+			cpg_rst_ddr_opt = <0x00000000>;
 
 			cpg_clk_on_tbl = <
 				0x0504 0x00030000

--- a/fdts/rzg2l-sbc.dts
+++ b/fdts/rzg2l-sbc.dts
@@ -94,6 +94,7 @@
 			cpg_selector_on_off = <1>;
 			cpg_early_setup = <1>;
 			cpg_mstop_setup = <0>;
+			cpg_rst_ddr_opt = <0x00000000>;
 
 			cpg_clk_on_tbl = <
 				0x0504 0x00030000

--- a/plat/renesas/rz/common/drivers/cpg.c
+++ b/plat/renesas/rz/common/drivers/cpg.c
@@ -480,7 +480,7 @@ static void cpg_reset_setup(void)
 void cpg_active_ddr(void (*disable_phy)(void))
 {
 	/* Assert the reset of DDRTOP */
-	CPG_REG_WRITE(CPG_RST_DDR, 0x005F0000 | (CPG_RST_DDR_OPT_VALUE << 16));
+	CPG_REG_WRITE(CPG_RST_DDR, 0x005F0000 | (g_cpg_fconf_cfg->cpg_rst_ddr_opt << 16));
 	CPG_REG_WRITE(CPG_OTHERFUNC2_REG, 0x00010000);
 	while ((CPG_REG_READ(CPG_RSTMON_DDR) & 0x0000005F) != 0x0000005F)
 		;
@@ -507,7 +507,7 @@ void cpg_active_ddr(void (*disable_phy)(void))
 	disable_phy();
 
 	/* De-assert axiY_ARESETn, regARESETn, reset_n */
-	CPG_REG_WRITE(CPG_RST_DDR, 0x005D005D | (CPG_RST_DDR_OPT_VALUE << 16) | CPG_RST_DDR_OPT_VALUE);
+	CPG_REG_WRITE(CPG_RST_DDR, 0x005D005D | (g_cpg_fconf_cfg->cpg_rst_ddr_opt << 16) | g_cpg_fconf_cfg->cpg_rst_ddr_opt);
 	while ((CPG_REG_READ(CPG_RSTMON_DDR) & 0x0000005D) != 0x00000000)
 		;
 
@@ -517,7 +517,7 @@ void cpg_active_ddr(void (*disable_phy)(void))
 void cpg_reset_ddr_mc(void)
 {
 	/* Assert rst_n, axiY_ARESETn, regARESETn */
-	CPG_REG_WRITE(CPG_RST_DDR, 0x005C0000 | (CPG_RST_DDR_OPT_VALUE << 16));
+	CPG_REG_WRITE(CPG_RST_DDR, 0x005C0000 | (g_cpg_fconf_cfg->cpg_rst_ddr_opt << 16));
 	CPG_REG_WRITE(CPG_OTHERFUNC2_REG, 0x00010000);
 	while ((CPG_REG_READ(CPG_RSTMON_DDR) & 0x0000005C) != 0x0000005C)
 		;
@@ -530,7 +530,7 @@ void cpg_reset_ddr_mc(void)
 	udelay(1);
 
 	/* De-assert axiY_ARESETn, regARESETn */
-	CPG_REG_WRITE(CPG_RST_DDR, 0x005C005C | (CPG_RST_DDR_OPT_VALUE << 16) | CPG_RST_DDR_OPT_VALUE);
+	CPG_REG_WRITE(CPG_RST_DDR, 0x005C005C | (g_cpg_fconf_cfg->cpg_rst_ddr_opt << 16) | g_cpg_fconf_cfg->cpg_rst_ddr_opt);
 	while ((CPG_REG_READ(CPG_RSTMON_DDR) & 0x0000005C) != 0x00000000)
 		;
 

--- a/plat/renesas/rz/common/include/rz_fconf.h
+++ b/plat/renesas/rz/common/include/rz_fconf.h
@@ -35,6 +35,7 @@ struct cpg_config_t {
 	uint32_t cpg_selector_on_off;
 	uint32_t cpg_early_setup;
 	uint32_t cpg_mstop_setup;
+	uint32_t cpg_rst_ddr_opt;
 };
 
 struct sysc_config_t {

--- a/plat/renesas/rz/common/rz_fconf.c
+++ b/plat/renesas/rz/common/rz_fconf.c
@@ -133,6 +133,11 @@ int fconf_populate_cpg_config(uintptr_t config)
 	read_prop_from_subnode(fdt, "/soc", cpg_path, "reg", 1, &cpg_config.cpg_base);
 	fconf_read_u32_props(fdt, cpg_node, cpg_props, (uint32_t **)cpg_targets, ARRAY_SIZE(cpg_props));
 
+	/* Specific for CPG type 0 (RZG2L, RZV2L) */
+	if (cpg_config.cpg_type == 0) {
+		read_prop_from_subnode(fdt, "/soc", cpg_path, "cpg_rst_ddr_opt", 0, &cpg_config.cpg_rst_ddr_opt);
+	}
+
 	return 0;
 }
 

--- a/tools/renesas/dts_creator/template/rzg2l_template.dts
+++ b/tools/renesas/dts_creator/template/rzg2l_template.dts
@@ -91,6 +91,7 @@
 			cpg_selector_on_off = <1>;
 			cpg_early_setup = <1>;
 			cpg_mstop_setup = <0>;
+			cpg_rst_ddr_opt_value = <0x00000000>;
 
 			cpg_clk_on_tbl = <
 				0x0504 0x00030000

--- a/tools/renesas/dts_creator/template/rzv2l_template.dts
+++ b/tools/renesas/dts_creator/template/rzv2l_template.dts
@@ -91,6 +91,7 @@
 			cpg_selector_on_off = <1>;
 			cpg_early_setup = <1>;
 			cpg_mstop_setup = <0>;
+			cpg_rst_ddr_opt_value = <0x00000020>;
 
 			cpg_clk_on_tbl = <
 				0x0504 0x00030000


### PR DESCRIPTION
- Support cpg_rst_ddr_opt in the device tree for specific setting values on RZ/G2L and RZ/V2L