### PR TITLE
rz-cmn: lts-v2.14.1: add OP-TEE BL32 support

### DIFF
--- a/plat/renesas/rz/common/bl2_plat_mem_params_desc.c
+++ b/plat/renesas/rz/common/bl2_plat_mem_params_desc.c
@@ -50,7 +50,10 @@ static bl_mem_params_node_t bl2_mem_params_descs[] = {
 		SET_STATIC_PARAM_HEAD(ep_info, PARAM_EP, VERSION_2,
 			entry_point_info_t, SECURE | EXECUTABLE),
 		.ep_info.pc = BL32_BASE,
-		.ep_info.spsr = 0,
+		.ep_info.spsr = SPSR_64(MODE_EL1, MODE_SP_ELX,
+			DISABLE_ALL_EXCEPTIONS),
+		/* arg2: NS DTB addr — OP-TEE injects firmware/optee node here */
+		.ep_info.args.arg2 = RZG2L_NS_DTB_ADDR,
 
 		SET_STATIC_PARAM_HEAD(image_info, PARAM_EP, VERSION_2,
 			image_info_t, 0),

--- a/plat/renesas/rz/common/include/platform_def.h
+++ b/plat/renesas/rz/common/include/platform_def.h
@@ -88,7 +88,7 @@
  ******************************************************************************/
 #ifndef SPD_none
 #define BL32_BASE				(0x44100000)
-#define BL32_LIMIT				(BL32_BASE + 0x100000)
+#define BL32_LIMIT				(BL32_BASE + 0x03D00000)	/* 61 MB, matches OP-TEE plat-rz CFG_TZDRAM_SIZE */
 #endif
 
 //#define REMOVE_UBOOT

--- a/plat/renesas/rz/common/include/rzg2l_def.h
+++ b/plat/renesas/rz/common/include/rzg2l_def.h
@@ -62,6 +62,11 @@
 #define RZG2L_DTB_LIMIT             (RZG2L_BL2_LIMIT)
 #define RZG2L_DTB_BASE              (0x2A000)
 
+/* Non-secure DTB address passed to OP-TEE (BL32 arg2) for DT node injection.
+ * Must match U-Boot fdt_addr (confirmed from boot log: fdt blob at 0x48000000).
+ */
+#define RZG2L_NS_DTB_ADDR           (0x48000000)
+
 /* Boot Info base address */
 #define RZG2L_BOOTINFO_BASE         (RZG2L_SRAM_BASE)
 

--- a/plat/renesas/rz/common/plat_security.c
+++ b/plat/renesas/rz/common/plat_security.c
@@ -146,23 +146,23 @@ static void plat_tzc_ddr_setup(void)
 
 		{
 			/* Region 1: */
-			.base = PLAT_FW_TZC_PROT_DRAM01_BASE,
-			.end  = PLAT_FW_TZC_PROT_DRAM01_END,
+			.base = PLAT_FW_TZC_PROT_DRAM1_BASE,
+			.end  = PLAT_FW_TZC_PROT_DRAM1_END,
 			.sec_attr = TZC_REGION_S_RDWR,
 			.nsaid_permissions = PLAT_TZC_REGION_ACCESS_S_UNPRIV
 		},
 
 		{
 			/* Region 2: */
-			.base = PLAT_TEE_TZC_PROT_DRAM01_BASE,
-			.end  = PLAT_TEE_TZC_PROT_DRAM01_END,
+			.base = PLAT_TEE_TZC_PROT_DRAM1_BASE,
+			.end  = PLAT_TEE_TZC_PROT_DRAM1_END,
 			.sec_attr = TZC_REGION_S_RDWR,
 			.nsaid_permissions = PLAT_TZC_REGION_ACCESS_S_UNPRIV
 		},
 
 		{
 			/* Region 3: */
-			.base = PLAT_TEE_TZC_PROT_DRAM01_END + 1,
+			.base = PLAT_TEE_TZC_PROT_DRAM1_END + 1,
 			.end  = UL(0xFFFFFFFFF),
 			.sec_attr = TZC_REGION_S_NONE,
 			.nsaid_permissions = PLAT_TZC_REGION_ACCESS_NS_UNPRIV

--- a/plat/renesas/rz/common/rz_common.mk
+++ b/plat/renesas/rz/common/rz_common.mk
@@ -196,6 +196,22 @@ ifneq (${TRUSTED_BOARD_BOOT},0)
 
 endif
 
+ifndef SHELL_COPY
+    define SHELL_COPY
+	$(Q)cp -f "$(1)" "$(2)"
+    endef
+endif
+ifndef SHELL_DELETE
+    define SHELL_DELETE
+	-$(Q)rm -f "$(1)"
+    endef
+endif
+ifndef SHELL_DELETE_ALL
+    define SHELL_DELETE_ALL
+	-$(Q)rm -rf $(1)
+    endef
+endif
+
 .PHONY: bl2-xspi bl2-emmc bl2-esd bl2-all
 
 define PLAT_BL2_VARIANT_RULE
@@ -203,23 +219,20 @@ bl2-$(1):
 	@echo "======================================="
 	@echo " Building BL2 for $(1)"
 	@echo "======================================="
-	rm -rf ${BUILD_PLAT}/bl2
-	mkdir -p ${BUILD_PLAT}/bl2
-	$(MAKE) PLAT=${PLAT} BOARD=${BOARD} PLAT_BL2_STORAGE=$(1) DEBUG=${DEBUG} bl2
-ifeq ($(1),esd)
-	$(MAKE) PLAT=${PLAT} BOARD=${BOARD} PLAT_BL2_STORAGE=$(1) DEBUG=${DEBUG} bl2_with_dtb
-endif
-	rm -f ${BUILD_PLAT}/bl2-$(1).bin
-	cp ${BUILD_PLAT}/bl2.bin ${BUILD_PLAT}/bl2-$(1).bin
+	$(MAKE) clean
+	$(call SHELL_DELETE_ALL, ${BUILD_PLAT}/bl2/*)
+	$(MAKE) PLAT=${PLAT} BOARD=${BOARD} PLAT_BL2_STORAGE=$(1) DEBUG=${DEBUG} SPD=${SPD} LD=${LD} bl2
+	$(call SHELL_DELETE,${BUILD_PLAT}/bl2-$(1).bin)
+	$(call SHELL_COPY,${BUILD_PLAT}/bl2.bin,${BUILD_PLAT}/bl2-$(1).bin)
 endef
 
 $(foreach variant,xspi emmc esd,$(eval $(call PLAT_BL2_VARIANT_RULE,$(variant))))
 
 # Build all storage variants of BL2
 bl2-all:
-	$(MAKE) PLAT=${PLAT} BOARD=${BOARD} DEBUG=${DEBUG} bl2-xspi
-	$(MAKE) PLAT=${PLAT} BOARD=${BOARD} DEBUG=${DEBUG} bl2-emmc
-	$(MAKE) PLAT=${PLAT} BOARD=${BOARD} DEBUG=${DEBUG} bl2-esd
+	$(MAKE) PLAT=${PLAT} BOARD=${BOARD} DEBUG=${DEBUG} SPD=${SPD} LD=${LD} bl2-xspi
+	$(MAKE) PLAT=${PLAT} BOARD=${BOARD} DEBUG=${DEBUG} SPD=${SPD} LD=${LD} bl2-emmc
+	$(MAKE) PLAT=${PLAT} BOARD=${BOARD} DEBUG=${DEBUG} SPD=${SPD} LD=${LD} bl2-esd
 	@echo "======================================="
 	@echo "All BL2 variants built successfully."
 	@echo "======================================="

--- a/plat/renesas/rz/soc/v2h/include/platform_def.h
+++ b/plat/renesas/rz/soc/v2h/include/platform_def.h
@@ -70,7 +70,7 @@
  ******************************************************************************/
 #ifndef SPD_none
 #define BL32_BASE				UL(0x44100000)
-#define BL32_LIMIT				(BL32_BASE + 0x100000)
+#define BL32_LIMIT				(BL32_BASE + 0x03D00000)	/* 61 MB, matches rzv2h_conf.mk CFG_TZDRAM_SIZE */
 #endif
 
 /*******************************************************************************


### PR DESCRIPTION
Add open-source OP-TEE BL32 support to TF-A `lts-v2.14.1` for the rz-cmn platform using the **tee-in-FIP** architecture: BL32 is loaded from FIP at runtime by BL2 (`--tos-fw`), not embedded in BL31 at compile time.